### PR TITLE
Don't send null bytes after URL encoded parameters

### DIFF
--- a/HTTPClient.cpp
+++ b/HTTPClient.cpp
@@ -312,7 +312,8 @@ HTTPClient::clientWrite(char byte, FILE* stream)
           char encoded[4] =
             { 0, 0, 0 };
           sprintf(encoded, "%%%2x", byte);
-          for (char i = 0; i < 4; i++)
+          // Write only the first three bytes, not the trailing null
+          for (char i = 0; i < 3; i++)
             {
               client->write(encoded[i]);
               if (client->debugCommunication)


### PR DESCRIPTION
In HTTPClient::clientWrite(), the encoding of a space character:

' '

was writing four bytes:

%, 2, 0, null

instead of the correct three bytes:

%, 2, 0

that is, '%20'. This commit changes the loop condition to write
only the first three bytes without the trailing null.
