### PR TITLE
Use const char* for requestType.

### DIFF
--- a/HTTPClient.cpp
+++ b/HTTPClient.cpp
@@ -200,7 +200,7 @@ HTTPClient::openClientFile()
 }
 
 char
-HTTPClient::sendUriAndHeaders(FILE* stream, char* hostName, char* requestType, char* uri,
+HTTPClient::sendUriAndHeaders(FILE* stream, char* hostName, const char* requestType, char* uri,
     http_client_parameter parameters[], http_client_parameter headers[])
 {
   fprintf_P(stream, requestType, uri);

--- a/HTTPClient.h
+++ b/HTTPClient.h
@@ -188,7 +188,7 @@ private:
   setEncoding(FILE* stream, char encode, char encodeReserved);
   //some HTTP helpers
   char
-  sendUriAndHeaders(FILE* stream, char* hostName, char* requestType, char* uri,
+  sendUriAndHeaders(FILE* stream, char* hostName, const char* requestType, char* uri,
       http_client_parameter parameters[], http_client_parameter headers[]);
   char
   sendContentPayload(FILE* stream, char* data);


### PR DESCRIPTION
# Compiling PachubePush Example
## Before

```
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp: In member function '__file* HTTPClient::getURI(char*, http_client_parameter*, http_client_parameter*)':
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp:79:14: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.h:191:3: error:   initializing argument 3 of 'char HTTPClient::sendUriAndHeaders(__file*, char*, char*, char*, http_client_parameter*, http_client_parameter*)' [-fpermissive]
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp: In member function '__file* HTTPClient::postURI(char*, http_client_parameter*, char*, http_client_parameter*)':
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp:108:14: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.h:191:3: error:   initializing argument 3 of 'char HTTPClient::sendUriAndHeaders(__file*, char*, char*, char*, http_client_parameter*, http_client_parameter*)' [-fpermissive]
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp: In member function '__file* HTTPClient::putURI(char*, http_client_parameter*, char*, http_client_parameter*)':
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.cpp:135:14: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
/home/ppicazo/Development/arduino/libraries/HTTPClient/HTTPClient.h:191:3: error:   initializing argument 3 of 'char HTTPClient::sendUriAndHeaders(__file*, char*, char*, char*, http_client_parameter*, http_client_parameter*)' [-fpermissive]
```
## After

```
Binary sketch size: 19656 bytes (of a 32256 byte maximum)
```
## Testing
- Tested on Fedora 16 using Ardiuno 1.0
- Tested on OSX using Arduino 1.0
