### PR TITLE
Fix warnings, NULL is meant for pointers only.

### DIFF
--- a/HTTPClient.cpp
+++ b/HTTPClient.cpp
@@ -409,9 +409,9 @@ HTTPClient::skipHeader(FILE* stream)
 {
   //skip over the header
   int httpReturnCode;
-  lastReturnCode = NULL;
+  lastReturnCode = -1;
 
-  if (stream == NULL) return NULL;
+  if (stream == NULL) return -1;
   http_stream_udata* udata = (http_stream_udata*) fdev_get_udata(stream);
   HTTPClient* client = udata->client;
 
@@ -421,7 +421,7 @@ HTTPClient::skipHeader(FILE* stream)
      delay(HTTPCLIENT_HEADER_READ_DELAY_ONCE);
 
   int res=fscanf_P(stream, PSTR("HTTP/1.1 %i"), &httpReturnCode);
-  if (res!=1) return NULL;
+  if (res!=1) return -1;
   lastReturnCode = httpReturnCode; // only set class variable when successfully matched, else it is NULL
   
   char inByte = '\0';
@@ -438,7 +438,7 @@ HTTPClient::skipHeader(FILE* stream)
         {
           //hmm, an error occured - lets just end this
           HTTPClient::closeStream(stream);
-          return NULL;
+          return -1;
         }
     }
   return 0;


### PR DESCRIPTION
Hello, I got some of these warnings when compiling:

``` c
HTTPClient/HTTPClient.cpp:412:18: warning: converting to non-pointer type 'int' from NULL [-Wconversion-null]
   lastReturnCode = NULL;
```

Since `int HTTPClient::skipHeader(FILE* stream)` returns an `int`...

Also usually NULL is defined as 0, so using that as an error case when 0 is also returned as success does not make much sense.

However, the return value for skipHeader is never checked anywhere.... so this is just to shut up the compiler mostly.
